### PR TITLE
Do not install libs to /usr/lib/libhybris-egl

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -58,10 +58,4 @@ package() {
   mkdir -p EGL
   cd EGL
   ln -s ../hybris/EGL/eglhybris.h .
-
-  install -m755 -d "${pkgdir}/usr/lib/libhybris-egl"
-
-  for i in $(find ${pkgdir}/usr/lib/ -name 'libEGL.so*' -or -name 'libGLES*' -or -name 'libwayland-egl.so*'); do
-    mv "$i" "${pkgdir}/usr/lib/libhybris-egl/"
-  done
 }


### PR DESCRIPTION
There are no conflicts with MESA anymore with enabled glvnd and this breaks library search.